### PR TITLE
Fix SVGs when using local_backend

### DIFF
--- a/packages/netlify-cms-backend-proxy/src/implementation.ts
+++ b/packages/netlify-cms-backend-proxy/src/implementation.ts
@@ -10,6 +10,7 @@ import {
   APIError,
   unsentRequest,
   UnpublishedEntry,
+  blobToFileObj,
 } from 'netlify-cms-lib-util';
 import AuthenticationPage from './AuthenticationPage';
 
@@ -38,8 +39,8 @@ const deserializeMediaFile = ({ id, content, encoding, path, name }: MediaFile) 
       byteArray[i] = decodedContent.charCodeAt(i);
     }
   }
-  const options = name.match(/.svg$/) ? { type: 'image/svg+xml' } : {};
-  const file = new File([byteArray], name, options);
+  const blob = new Blob([byteArray]);
+  const file = blobToFileObj(name, blob);
   const url = URL.createObjectURL(file);
   return { id, name, path, file, size: file.size, url, displayURL: url };
 };

--- a/packages/netlify-cms-backend-proxy/src/implementation.ts
+++ b/packages/netlify-cms-backend-proxy/src/implementation.ts
@@ -38,7 +38,8 @@ const deserializeMediaFile = ({ id, content, encoding, path, name }: MediaFile) 
       byteArray[i] = decodedContent.charCodeAt(i);
     }
   }
-  const file = new File([byteArray], name);
+  const options = name.match(/.svg$/) ? { type: 'image/svg+xml' } : {};
+  const file = new File([byteArray], name, options);
   const url = URL.createObjectURL(file);
   return { id, name, path, file, size: file.size, url, displayURL: url };
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines.

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first two fields are mandatory:
-->

**Summary**

When using `local_backend: true` and `npx netlify-cms-proxy-server`, SVG images are broken in the media browser and entrycard interfaces. Most of the other backends have SVG detection and add a filetype to the `File` blob. This brings that fix to the proxy backend. 

There may be a bigger refactor here that would reduce duplication of code across backends, but I'm not the one to take that on.

The broken images were driving me nuts.

Before:

<img width="1202" alt="Screen Shot 2020-08-24 at 9 54 08 PM" src="https://user-images.githubusercontent.com/71791/91121190-8585c800-e654-11ea-8958-3a1b949f00b1.png">

After:

<img width="1197" alt="Screen Shot 2020-08-24 at 9 54 21 PM" src="https://user-images.githubusercontent.com/71791/91121213-8fa7c680-e654-11ea-9979-af7ee3839b03.png">

**Test plan**

This is a two line code change that adds an option to the `new File`. I did not add a unit test, but I did build the change and confirm the fix works.

**A picture of a cute animal (not mandatory but encouraged)**

![IMG_0032](https://user-images.githubusercontent.com/71791/91121534-3c824380-e655-11ea-85bc-f908794ce467.jpeg)

